### PR TITLE
Feature/reworkMare

### DIFF
--- a/Modules/GameOptionsSender/PlayerGameOptionsSender.cs
+++ b/Modules/GameOptionsSender/PlayerGameOptionsSender.cs
@@ -10,6 +10,7 @@ using TownOfHostY.Roles.Core;
 using TownOfHostY.Roles.Neutral;
 using TownOfHostY.Roles.Crewmate;
 using TownOfHostY.Roles.AddOns.Common;
+using TownOfHostY.Roles.Impostor;
 
 namespace TownOfHostY.Modules
 {
@@ -113,6 +114,7 @@ namespace TownOfHostY.Modules
                 }
             }
             Blinder.ApplyGameOptionsByOther(player.PlayerId, opt);
+            NightMare.ApplyGameOptionsByOther(player.PlayerId, opt);
 
             if (Main.AllPlayerKillCooldown.TryGetValue(player.PlayerId, out var killCooldown))
             {

--- a/Modules/NameColorManager.cs
+++ b/Modules/NameColorManager.cs
@@ -12,7 +12,7 @@ namespace TownOfHostY
         public static string ApplyNameColorData(this string name, PlayerControl seer, PlayerControl target, bool isMeeting)
         {
             if (!AmongUsClient.Instance.IsGameStarted) return name;
-            if (isMeeting && Snitch.IsCannotConfirmKillRoles(seer,target)) return name;
+            if (isMeeting && Snitch.IsCannotConfirmKillRoles(seer, target)) return name;
 
             if (!TryGetData(seer, target, out var colorCode))
             {
@@ -35,6 +35,7 @@ namespace TownOfHostY
                 || target.Is(CustomRoles.GM)
                 || (seer.Is(CustomRoleTypes.Impostor) && target.Is(CustomRoleTypes.Impostor) && !seer.Is(CustomRoles.StrayWolf) && !target.Is(CustomRoles.StrayWolf))
                 || Mare.KnowTargetRoleColor(target, isMeeting)
+                || NightMare.KnowTargetRoleColor(target, isMeeting)
                 || (target.Is(CustomRoles.Workaholic) && Workaholic.Seen)
                 || target.Is(CustomRoles.Rainbow)
                 || FortuneTeller.KnowTargetRoleColor(seer, target, isMeeting)

--- a/Modules/OptionSerializer.cs
+++ b/Modules/OptionSerializer.cs
@@ -81,8 +81,8 @@ public static class OptionSerializer
     /// </summary>
     /// <returns>生成された文字列</returns>
     public static string GenerateVanillaOptionsString()
-    {
-        byte[] bytes = GameOptionsManager.Instance.gameOptionsFactory.ToBytes(GameOptionsManager.Instance.CurrentGameOptions);
+    {// エイプリルフール無効
+        byte[] bytes = GameOptionsManager.Instance.gameOptionsFactory.ToBytes(GameOptionsManager.Instance.CurrentGameOptions, false);
         return Convert.ToBase64String(bytes);
     }
     /// <summary>

--- a/Patches/GameStartManagerPatch.cs
+++ b/Patches/GameStartManagerPatch.cs
@@ -247,7 +247,7 @@ namespace TownOfHostY
                 Main.LastShapeshifterCooldown.Value = AURoleOptions.ShapeshifterCooldown;
                 AURoleOptions.ShapeshifterCooldown = 0f;
 
-                PlayerControl.LocalPlayer.RpcSyncSettings(GameOptionsManager.Instance.gameOptionsFactory.ToBytes(opt));
+                PlayerControl.LocalPlayer.RpcSyncSettings(GameOptionsManager.Instance.gameOptionsFactory.ToBytes(opt, AprilFoolsMode.IsAprilFoolsModeToggledOn));
 
                 __instance.ReallyBegin(false);
                 return false;
@@ -285,12 +285,12 @@ namespace TownOfHostY
                 if (GameStates.IsCountDown)
                 {
                     Main.NormalOptions.KillCooldown = Options.DefaultKillCooldown;
-                    PlayerControl.LocalPlayer.RpcSyncSettings(GameOptionsManager.Instance.gameOptionsFactory.ToBytes(GameOptionsManager.Instance.CurrentGameOptions));
+                    PlayerControl.LocalPlayer.RpcSyncSettings(GameOptionsManager.Instance.gameOptionsFactory.ToBytes(GameOptionsManager.Instance.CurrentGameOptions, AprilFoolsMode.IsAprilFoolsModeToggledOn));
                 }
             }
         }
     }
-    
+
     [HarmonyPatch(typeof(TextBoxTMP), nameof(TextBoxTMP.SetText))]
     public static class HiddenTextPatch
     {

--- a/Resources/string.csv
+++ b/Resources/string.csv
@@ -51,6 +51,7 @@
 "EvilDyer","Evil Dyer","イビル真っ赤",
 "BestieWolf","Bestie Wolf","ベスティーウルフ",
 "EvilGuesser","Evil Guesser","イビルゲッサー","","","",""
+"NightMare","Night Mare","ナイトメアー","","","",""
 
 "CustomImpostorInfo","I can now use abilities like that","あんな能力も使えるようになりました",
 "EvilWatcherInfo","Gaze upon all votes","みんなの投票に目を光らせよう","你可以看见所有人的投票，注意他们的选择","注意所有人的投票","Вы видите цвета голосов","Veja todos os votos"
@@ -89,6 +90,7 @@
 "BestieWolfInfo","I'll be in support","うちはサポートにまわります",
 "AfterBestieWolfInfo","I lost my friends, why..?","仲間おらんなった、、なんで、、",
 "EvilGuesserInfo","Guess the Player Role","役職を推測しよう","","","",""
+"NightMareInfo","Take control of the darkness!","暗闇を支配しろ","","","",""
 
 "CustomImpostorInfoLong","(Impostors):\nImpostor with the ability to Add-On to attributes set by the host.","[インポスター陣営]\nホストによって設定された属性の能力をもつインポスター。",
 "EvilWatcherInfoLong","(Impostors):\nYou can see everyone's votes even if anonymous voting is on.","(インポスター陣営):\n全員の投票先を見ることができる。","(内鬼阵营):\n会议时窥视者可以看到所有人的投票。","(狼人陣營):\n會議時觀察者可以看到所有人的投票。","(Предатель):\nNice Watcher может видеть все цвета голосов несмотря на анонимное голосование.","(Impostores):\nVocê consegue ver os votos de todos, mesmo que os votos anônimos estejam ligados."
@@ -124,6 +126,7 @@
 "EvilDyerInfoLong","(Impostors):\nWhen he kills someone, everyone turns red for a certain period of time.","[インポスター陣営]\n自身が誰かキルすると全員が一定時間、赤色の姿になる。",
 "BestieWolfInfoLong","(Impostors):\nHe is supportive of his partner because of his love for his companions, but when he becomes a lone Impostor, he becomes lonely and goes berserk.\n\nWhen multiple Impostors are alive, the buff Add-On is given to the partner Impostor depending on the number of kills.\nIf you are the sole Impostor and there is someone else within view of the kill target at the time of the kill, you will kill that person at the same time. Additional kills are limited to one person per kill, and when simultaneous kills occur, a kill flash is visible from all viewpoints.","[インポスター陣営]\n仲間想いなため相方へのサポートをするが、単独な狼になった時には孤独が寂しくなり暴走する。\n\n複数インポスターが生存時、キル回数によって相方インポスターにバフ属性を付与する。\n自身が単独インポスターになった場合、キルする時にそのキル対象の見える範囲内に誰かいた場合、その人まで同時にキルする。追加キルは1キル1人までで、同時キルが起こった時は全視点でキルフラッシュが見える。"
 "EvilGuesserInfoLong","(Impostors):\nImpostor guessing the player's role.\nYou can kill a player during a meeting by guessing their role.","(インポスター陣営):\n特殊能力を持つインポスターです。\n会議中に他のプレイヤーの役職を当てる事でそのプレイヤーを死亡させることができます。","","","",""
+"NightMareInfoLong","(Impostors):\nIf a kill is made during a power outage,\nthe next kill cool will be shortened.\nMovement speed is also increased.\nHowever, the name will be red.\nAlso, during a normal kill, not during a power outage, the \nThe visibility of all but the imposter is reduced.","(インポスター陣営):\n自身が起こした停電中にキルをすると、\n次のキルクールが短くなります。\n移動速度も上昇します。\nしかし、名前が赤くなります。\n※会議後は10秒後に赤くなる。\nまた停電時ではない通常キルの時は、\nインポスター以外の視界が数秒狭くなります。","","","",""
 
 #イビルハッカ
 "EvilHacker","Evil Replicator","イビルハッカー...?",
@@ -824,6 +827,10 @@ GhostCanSeeOtherTasks,"Ghosts Can't See Other Tasks","幽霊が他人のタス�
 "BestieWolfBuffAddonAssignTarget3","Buff Add-On To Be Granted ③","付与するバフ属性③",
 "BestieWolfBuffAddonAssignTarget4","Buff Add-On To Be Granted ④","付与するバフ属性④",
 "BestieWolfBuffAddonAssignTarget5","Buff Add-On To Be Granted ⑤","付与するバフ属性⑤",
+"NightMareSpeedInLightsOut","Mare Add Player Add Speed In Lights Out","停電時の加速値",
+"NightMareKillCooldownInLightsOut","KILL COOL during power outages","停電時のキルクール"
+"NightMareNormalKillCrewVision","Crew visibility during normal kills","通常キル時のクルー陣営の視界"
+"NightMareDarkSeconds","Number of seconds it goes dark during a normal kill.","通常キル時の暗転する秒数"
 
 # マッドメイト
 "CanMakeMadmateCount","Sidekick Madmate Max Count","サイドキックマッドメイト","变形者可以招募叛徒的数量","變形者招募叛徒最大人數","Максимум союзников Безумца","Máximo de Tripulantes Loucos Ajudantes"

--- a/Roles/Core/CustomRoleManager.cs
+++ b/Roles/Core/CustomRoleManager.cs
@@ -450,6 +450,7 @@ public enum CustomRoles
     EvilDyer,
     BestieWolf,
     EvilGuesser,
+    NightMare,
     //Madmate
     MadGuardian,
     Madmate,
@@ -508,7 +509,7 @@ public enum CustomRoles
     Rabbit,
     VentManager,
     Counselor,
-    NiceGuesser, 
+    NiceGuesser,
 
     Potentialist,
     //Neutral

--- a/Roles/Impostor/Y/NightMare.cs
+++ b/Roles/Impostor/Y/NightMare.cs
@@ -1,0 +1,34 @@
+using AmongUs.GameOptions;
+
+using TownOfHostY.Roles.Core;
+using TownOfHostY.Roles.Core.Class;
+using TownOfHostY.Roles.Core.Interfaces;
+
+namespace TownOfHostY.Roles.Impostor;
+public sealed class NightMare : VoteGuesser, IImpostor
+{
+    public static readonly SimpleRoleInfo RoleInfo =
+         SimpleRoleInfo.Create(
+            typeof(NightMare),
+            player => new NightMare(player),
+            CustomRoles.NightMare,
+            () => RoleTypes.Impostor,
+            CustomRoleTypes.Impostor,
+            (int)Options.offsetId.ImpY + 1400,
+            SetupOptionItem,
+            "ナイトメアー"
+        );
+    public NightMare(PlayerControl player)
+    : base(
+        RoleInfo,
+        player)
+    {
+
+    }
+    enum OptionName
+    {
+    }
+    public static void SetupOptionItem()
+    {
+    }
+}

--- a/Roles/Impostor/Y/NightMare.cs
+++ b/Roles/Impostor/Y/NightMare.cs
@@ -14,7 +14,7 @@ public sealed class NightMare : VoteGuesser, IImpostor
             CustomRoles.NightMare,
             () => RoleTypes.Impostor,
             CustomRoleTypes.Impostor,
-            (int)Options.offsetId.ImpY + 1400,
+            (int)Options.offsetId.ImpY + 1500,
             SetupOptionItem,
             "ナイトメアー"
         );
@@ -23,12 +23,35 @@ public sealed class NightMare : VoteGuesser, IImpostor
         RoleInfo,
         player)
     {
-
+        SpeedInLightsOut = OptionSpeedInLightsOut.GetFloat();
+        KillCooldownInLightsOut = OptionKillCooldownInLightsOut.GetFloat();
+        NormalKillCrewVision = OptionNormalKillCrewVision.GetFloat();
+        DarkSeconds = OptionDarkSeconds.GetFloat();
     }
+    private static OptionItem OptionKillCooldownInLightsOut;
+    private static OptionItem OptionSpeedInLightsOut;
+    private static OptionItem OptionNormalKillCrewVision;
+    private static OptionItem OptionDarkSeconds;
     enum OptionName
     {
+        NightMareSpeedInLightsOut,
+        NightMareKillCooldownInLightsOut,
+        NightMareNormalKillCrewVision,
+        NightMareDarkSeconds,
     }
+    private float SpeedInLightsOut;          //停電時の移動速度
+    private float KillCooldownInLightsOut;   //停電時のキルクール
+    private float NormalKillCrewVision;　　　 //通常キル時のクルー陣営の視界
+    private float DarkSeconds;               //通常キル時の暗転する秒数
     public static void SetupOptionItem()
     {
+        OptionSpeedInLightsOut = FloatOptionItem.Create(RoleInfo, 10, OptionName.NightMareSpeedInLightsOut, new(0.1f, 0.5f, 0.1f), 0.3f, false)
+            .SetValueFormat(OptionFormat.Multiplier);
+        OptionKillCooldownInLightsOut = FloatOptionItem.Create(RoleInfo, 11, OptionName.NightMareKillCooldownInLightsOut, new(2.5f, 180f, 2.5f), 15f, false)
+            .SetValueFormat(OptionFormat.Seconds);
+        OptionNormalKillCrewVision = FloatOptionItem.Create(RoleInfo, 12, OptionName.NightMareNormalKillCrewVision, new(0f, 5f, 0.25f), 2f, false)
+            .SetValueFormat(OptionFormat.Multiplier);
+        OptionDarkSeconds = FloatOptionItem.Create(RoleInfo, 13, OptionName.NightMareDarkSeconds, new(0, 100, 1), 7, false)
+        .SetValueFormat(OptionFormat.Seconds);
     }
 }

--- a/Roles/Impostor/Y/NightMare.cs
+++ b/Roles/Impostor/Y/NightMare.cs
@@ -27,6 +27,7 @@ public sealed class NightMare : VoteGuesser, IImpostor
         KillCooldownInLightsOut = OptionKillCooldownInLightsOut.GetFloat();
         NormalKillCrewVision = OptionNormalKillCrewVision.GetFloat();
         DarkSeconds = OptionDarkSeconds.GetFloat();
+        IsAccelerated = false;
     }
     private static OptionItem OptionKillCooldownInLightsOut;
     private static OptionItem OptionSpeedInLightsOut;
@@ -43,6 +44,7 @@ public sealed class NightMare : VoteGuesser, IImpostor
     private float KillCooldownInLightsOut;   //停電時のキルクール
     private float NormalKillCrewVision;　　　 //通常キル時のクルー陣営の視界
     private float DarkSeconds;               //通常キル時の暗転する秒数
+    private bool IsAccelerated;  　　　　　　 //加速済みかフラグ
     public static void SetupOptionItem()
     {
         OptionSpeedInLightsOut = FloatOptionItem.Create(RoleInfo, 10, OptionName.NightMareSpeedInLightsOut, new(1.2f, 10.0f, 0.2f), 1.2f, false)
@@ -53,5 +55,18 @@ public sealed class NightMare : VoteGuesser, IImpostor
             .SetValueFormat(OptionFormat.Multiplier);
         OptionDarkSeconds = FloatOptionItem.Create(RoleInfo, 13, OptionName.NightMareDarkSeconds, new(0, 100, 1), 7, false)
         .SetValueFormat(OptionFormat.Seconds);
+    }
+    public override void ApplyGameOptions(IGameOptions opt)
+    {
+        if (Utils.IsActive(SystemTypes.Electrical) && !IsAccelerated)
+        { //停電中で加速済みでない時。
+            IsAccelerated = true;
+            Main.AllPlayerSpeed[Player.PlayerId] += SpeedInLightsOut;//Mareの速度を加算
+        }
+        else if (!Utils.IsActive(SystemTypes.Electrical) && IsAccelerated)
+        { //停電中ではなく加速済みになっている場合
+            IsAccelerated = false;
+            Main.AllPlayerSpeed[Player.PlayerId] -= SpeedInLightsOut;//Mareの速度を減算
+        }
     }
 }

--- a/Roles/Impostor/Y/NightMare.cs
+++ b/Roles/Impostor/Y/NightMare.cs
@@ -99,6 +99,21 @@ public sealed class NightMare : VoteGuesser, IImpostor
             NameColorManager.Add(Killer.PlayerId, Killer.PlayerId, RoleInfo.RoleColorCode);
         }
     }
+    public override void AfterMeetingTasks()
+    {
+        if (Player.IsAlive())
+        {//生存していたらキルクールリセット
+            Player.RpcResetAbilityCooldown();
+            _ = new LateTask(() =>
+            {
+                //まだ停電が直っていなければキル可能モードに
+                if (Utils.IsActive(SystemTypes.Electrical))
+                {
+                    NameColorRED = true;
+                }
+            }, 10.0f, "NightMare NameColorRED");
+        }
+    }
     public static bool KnowTargetRoleColor(PlayerControl target, bool isMeeting)
         => !isMeeting && NameColorRED && target.Is(CustomRoles.NightMare);
 }

--- a/Roles/Impostor/Y/NightMare.cs
+++ b/Roles/Impostor/Y/NightMare.cs
@@ -39,17 +39,17 @@ public sealed class NightMare : VoteGuesser, IImpostor
         NightMareNormalKillCrewVision,
         NightMareDarkSeconds,
     }
-    private float SpeedInLightsOut;          //停電時の移動速度
+    private float SpeedInLightsOut;          //停電時の移動速度の加速値
     private float KillCooldownInLightsOut;   //停電時のキルクール
     private float NormalKillCrewVision;　　　 //通常キル時のクルー陣営の視界
     private float DarkSeconds;               //通常キル時の暗転する秒数
     public static void SetupOptionItem()
     {
-        OptionSpeedInLightsOut = FloatOptionItem.Create(RoleInfo, 10, OptionName.NightMareSpeedInLightsOut, new(0.1f, 0.5f, 0.1f), 0.3f, false)
+        OptionSpeedInLightsOut = FloatOptionItem.Create(RoleInfo, 10, OptionName.NightMareSpeedInLightsOut, new(1.2f, 10.0f, 0.2f), 1.2f, false)
             .SetValueFormat(OptionFormat.Multiplier);
-        OptionKillCooldownInLightsOut = FloatOptionItem.Create(RoleInfo, 11, OptionName.NightMareKillCooldownInLightsOut, new(2.5f, 180f, 2.5f), 15f, false)
+        OptionKillCooldownInLightsOut = FloatOptionItem.Create(RoleInfo, 11, OptionName.NightMareKillCooldownInLightsOut, new(0.0f, 180f, 2.5f), 15f, false)
             .SetValueFormat(OptionFormat.Seconds);
-        OptionNormalKillCrewVision = FloatOptionItem.Create(RoleInfo, 12, OptionName.NightMareNormalKillCrewVision, new(0f, 5f, 0.25f), 2f, false)
+        OptionNormalKillCrewVision = FloatOptionItem.Create(RoleInfo, 12, OptionName.NightMareNormalKillCrewVision, new(0.0f, 3.0f, 0.1f), 0.1f, false)
             .SetValueFormat(OptionFormat.Multiplier);
         OptionDarkSeconds = FloatOptionItem.Create(RoleInfo, 13, OptionName.NightMareDarkSeconds, new(0, 100, 1), 7, false)
         .SetValueFormat(OptionFormat.Seconds);

--- a/TownOfHost.csproj
+++ b/TownOfHost.csproj
@@ -18,8 +18,8 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-    	<Reference Include="$(AmongUs)\BepInEx\core\*.dll" />
-    	<Reference Include="$(AmongUs)\BepInEx\interop\*.dll" />
+    	<Reference Include="C:\Program Files (x86)\Steam\steamapps\common\Among Us_TownOfHost-Y_dev\BepInEx\core\*.dll" />
+    	<Reference Include="C:\Program Files (x86)\Steam\steamapps\common\Among Us_TownOfHost-Y_dev\BepInEx\interop\*.dll" />
     	<EmbeddedResource Include=".\Resources\*.png" />
     	<EmbeddedResource Include=".\Resources\string.csv" />
 	</ItemGroup>
@@ -36,7 +36,7 @@
 		</PackageReference>
 	</ItemGroup>
 
-	<Target Name="Copy" AfterTargets="Build" Condition="'$(AmongUs)' != ''">
-    	<Copy SourceFiles="$(OutputPath)$(AssemblyName).dll" DestinationFolder="$(AmongUs)/BepInEx/plugins/" Condition="'$(Configuration)' == 'Debug'" />
+	<Target Name="Copy" AfterTargets="Build" Condition="'C:\Program Files (x86)\Steam\steamapps\common\Among Us_TownOfHost-Y_dev' != ''">
+    	<Copy SourceFiles="$(OutputPath)$(AssemblyName).dll" DestinationFolder="C:\Program Files (x86)\Steam\steamapps\common\Among Us_TownOfHost-Y_dev/BepInEx/plugins/" />
 	</Target>
 </Project>


### PR DESCRIPTION

〈能力①〉
　自身が起こした停電中にキルすると
　次のキルクールが短くなる。
　足の速度が○○x早くなる。
　しかし、名前が赤く具現化する

　※会議を挟んだ場合
　　→湧き後10秒後に赤くなる
　　→通常のキルクールでスタート


〈能力②〉
　停電以外でキルすると
　◯◯秒間生存者の視界が○○%減する


⚠️NightMareが通常キルした際にクルーの視界が狭まりますが、
Mod入れてない方々は狭くなりませんでした。
※同期が上手く行ってなさそう。
(この辺り教えてもらえると嬉しいです、)